### PR TITLE
ci: skip deploy without ssh creds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
         run: npm run stress-test
         working-directory: backend
       - name: deploy
+        if: ${{ secrets.SWARM_HOST != '' && secrets.SSH_USER != '' && secrets.SSH_KEY != '' }}
         uses: appleboy/ssh-action@v0.1.6
         with:
           host: ${{ secrets.SWARM_HOST }}


### PR DESCRIPTION
## Summary
- avoid failing `appleboy/ssh-action` step when secrets are not provided

## Testing
- `npm test`
- `npm run lint -- --fix`
- `npm run build:ui`
- `npm run build:api`
- `npm run stress-test` *(fails: listen EADDRINUSE: address already in use :::3000)*

------
https://chatgpt.com/codex/tasks/task_e_6891908457fc8329b71a5fbc7094c7d6